### PR TITLE
Audio: add fluidsynth + GM/GS soundfonts

### DIFF
--- a/ansible/vars.yml
+++ b/ansible/vars.yml
@@ -48,6 +48,9 @@ common_packages:
   - ardour-lv2-plugins
   - ardour-video-timeline
   - gh
+  - fluidsynth
+  - fluid-soundfont-gm
+  - fluid-soundfont-gs
 
 
 # Spacemacs branch to install in ~/.emacs.d


### PR DESCRIPTION
Adds MIDI synthesis tools:

- fluidsynth
- fluid-soundfont-gm
- fluid-soundfont-gs

These enable GM/GS MIDI playback (e.g., with Ardour).
